### PR TITLE
style: adjust splash screen delay and animation timings

### DIFF
--- a/app/src/main/java/com/example/skinshine/ui/splash/SplashActivity.java
+++ b/app/src/main/java/com/example/skinshine/ui/splash/SplashActivity.java
@@ -16,7 +16,7 @@ import com.example.skinshine.R;
 
 public class SplashActivity extends AppCompatActivity {
 
-    private static final int SPLASH_DELAY = 2000;
+    private static final int SPLASH_DELAY = 3000;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/res/anim/splash_logo_animation.xml
+++ b/app/src/main/res/anim/splash_logo_animation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="800"
+    android:duration="0"
     android:fillAfter="true">
 
     <scale
@@ -10,12 +10,12 @@
         android:toYScale="1.0"
         android:pivotX="50%"
         android:pivotY="50%"
-        android:duration="400"
+        android:duration="0"
         android:interpolator="@android:anim/bounce_interpolator" />
 
     <alpha
         android:fromAlpha="0.0"
         android:toAlpha="1.0"
-        android:duration="200" />
+        android:duration="0" />
 
 </set>

--- a/app/src/main/res/anim/splash_slogan_animation.xml
+++ b/app/src/main/res/anim/splash_slogan_animation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:duration="400"
-    android:startOffset="500"
+    android:startOffset="100"
     android:fillAfter="true">
 
     <alpha

--- a/app/src/main/res/anim/splash_text_animation.xml
+++ b/app/src/main/res/anim/splash_text_animation.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="800"
-    android:startOffset="500"
+    android:duration="500"
+    android:startOffset="100"
     android:fillAfter="true">
 
     <translate
         android:fromYDelta="100%"
         android:toYDelta="0%"
-        android:duration="800"
+        android:duration="200"
         android:interpolator="@android:anim/decelerate_interpolator" />
 
     <alpha
         android:fromAlpha="0.0"
         android:toAlpha="1.0"
-        android:duration="400" />
+        android:duration="250" />
 
 </set>


### PR DESCRIPTION
Increased the splash screen delay from 2 to 3 seconds in SplashActivity. Updated splash logo, slogan, and text animation XMLs to reduce or remove durations and start offsets, resulting in faster or immediate animations for a snappier splash experience.