### PR TITLE
Fix/product detail

### DIFF
--- a/app/src/main/java/com/example/skinshine/ui/cart/CartFragment.java
+++ b/app/src/main/java/com/example/skinshine/ui/cart/CartFragment.java
@@ -13,6 +13,9 @@ import android.app.AlertDialog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -51,6 +54,15 @@ public class CartFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        ViewCompat.setOnApplyWindowInsetsListener(view, new OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat insets) {
+                int bottomInset = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+                v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), bottomInset);
+                return insets;
+            }
+        });
 
         if (FirebaseAuth.getInstance().getCurrentUser() == null) {
             Toast.makeText(getContext(), "Vui lòng đăng nhập để xem giỏ hàng", Toast.LENGTH_SHORT).show();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.11.0"
 compiler = "4.16.0"
 firebaseBom = "33.15.0"
 glide = "4.16.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jun 01 21:54:26 ICT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request introduces updates to the `CartFragment` UI to handle window insets dynamically and upgrades Gradle-related dependencies. The most important changes include adding an `OnApplyWindowInsetsListener` to adjust padding based on navigation bar insets and updating Gradle and Android Gradle Plugin versions for compatibility.

### UI Enhancements:
* [`app/src/main/java/com/example/skinshine/ui/cart/CartFragment.java`](diffhunk://#diff-fd5e9a2f4a57c72ebbdfdc4ff089dd0e9eb768c698b253855a5b90080eb2e08aR16-R18): Added an `OnApplyWindowInsetsListener` to dynamically adjust the bottom padding of the `CartFragment` view based on navigation bar insets. This improves UI responsiveness across devices with varying screen configurations. [[1]](diffhunk://#diff-fd5e9a2f4a57c72ebbdfdc4ff089dd0e9eb768c698b253855a5b90080eb2e08aR16-R18) [[2]](diffhunk://#diff-fd5e9a2f4a57c72ebbdfdc4ff089dd0e9eb768c698b253855a5b90080eb2e08aR58-R66)

### Gradle Updates:
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R2): Updated the Android Gradle Plugin (AGP) version from `8.10.1` to `8.11.0` for compatibility with the latest tools.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL4-R4): Upgraded Gradle distribution URL from `8.11.1` to `8.13` for improved build performance and support for newer features.