### PR TITLE
fix: remove duplicate intent-filter from MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -31,19 +30,12 @@
             android:exported="true"
             android:windowSoftInputMode="adjustPan"
             android:launchMode="singleTask">
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="skinshine" android:host="zalopay" android:pathPrefix="/callback"/>
             </intent-filter>
-
         </activity>
         <activity
             android:name=".ui.login.LoginActivity"


### PR DESCRIPTION
Eliminated a redundant MAIN/LAUNCHER intent-filter from MainActivity in AndroidManifest.xml, leaving only the VIEW intent-filter for deep linking. This streamlines the manifest and avoids duplicate launcher entries.